### PR TITLE
Update did-core to did for github and editor draft links

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     //implementationReportURI: "https://w3c.github.io/did-test-suite/",
 
     // Editor's Draft URL
-    edDraftURI: "https://w3c.github.io/did-core/",
+    edDraftURI: "https://w3c.github.io/did/",
 
     // subtitle for the spec
     subtitle: "Core architecture, data model, and representations",
@@ -63,7 +63,7 @@
       "informative-dfn": false
     },
     github: {
-      repoURL: "https://github.com/w3c/did-core/",
+      repoURL: "https://github.com/w3c/did/",
       branch: "main"
     },
     includePermalinks: false,


### PR DESCRIPTION
The URL - https://w3c.github.io/did-core/ gives a 404.

Also, as a side question. Should the URL https://www.w3.org/TR/did/upcoming/ resolve to the latest editor draft? It currently does not.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-core/pull/881.html" title="Last updated on Feb 25, 2025, 1:12 PM UTC (77daa15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/881/e2591dc...wip-abramson:77daa15.html" title="Last updated on Feb 25, 2025, 1:12 PM UTC (77daa15)">Diff</a>