### PR TITLE
Add text clarifying where group controllers might be listed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4025,10 +4025,10 @@ labeled, "DID Subject".
 In the case of group control, the [=DID controllers=] are expected to act
 together in some fashion, such as when using a cryptographic algorithm that
 requires multiple digital signatures ("multi-sig") or a threshold number of
-digital signatures ("m-of-n"). The expression of these additional thresholds for
+digital signatures ("m-of-n"). These additional thresholds for
 verifying a proof can be expressed in a [=verification method=] as described in
 Section [[[#verification-methods]]] or can be an intrinsic part of the
-[=verification method=] where the number of [=DID controllers=] that
+verification material of the [=verification method=], where the number of [=DID controllers=] that
 participated in the generation of a particular digital signature are hidden for
 privacy reasons.
         </p>

--- a/index.html
+++ b/index.html
@@ -4030,7 +4030,7 @@ verifying a proof can be expressed in a [=verification method=] as described in
 Section [[[#verification-methods]]] or can be an intrinsic part of the
 verification material of the [=verification method=], where the number of [=DID controllers=] that
 participated in the generation of a particular digital signature are hidden for
-privacy reasons.
+privacy reasons. Verification methods that require a proof be produced by a combination of cryptographic operations performed by members of a group can be used to control the contents of a DID document; exactly how this is realized depends on individual DID method specifications.
         </p>
         <p>
 From a functional standpoint, this option is

--- a/index.html
+++ b/index.html
@@ -4025,7 +4025,15 @@ labeled, "DID Subject".
 In the case of group control, the [=DID controllers=] are expected to act
 together in some fashion, such as when using a cryptographic algorithm that
 requires multiple digital signatures ("multi-sig") or a threshold number of
-digital signatures ("m-of-n"). From a functional standpoint, this option is
+digital signatures ("m-of-n"). The expression of these additional thresholds for
+verifying a proof can be expressed in a [=verification method=] as described in
+Section [[[#verification-methods]]] or can be an intrinsic part of the
+[=verification method=] where the number of [=DID controllers=] that
+participated in the generation of a particular digital signature are hidden for
+privacy reasons.
+        </p>
+        <p>
+From a functional standpoint, this option is
 similar to a single [=DID controller=] because, although each of the
 [=DID controllers=] in the [=DID controller=] group has its own graph
 node, the actual control collapses into a single logical graph node


### PR DESCRIPTION
This PR is an attempt to address issue #839 by adding text clarifying where group controllers might be listed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/883.html" title="Last updated on Mar 26, 2025, 3:44 PM UTC (5caf733)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/883/6939993...5caf733.html" title="Last updated on Mar 26, 2025, 3:44 PM UTC (5caf733)">Diff</a>