### PR TITLE
Clarify restrictions on identifiers used in DID documents.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1586,6 +1586,27 @@ DIDs as defined in Section [[[#did-syntax]]]. The process of authorizing a
 
       </section>
 
+      <section>
+        <h3>Identifier Restrictions</h3>
+        <p>
+Identifiers used in a [=DID document=] to identify a [=DID subject=] or a [=DID
+Controller=] do not allow the use of query parameters or fragment identifiers.
+Implementers are urged to pay particular attention to the list of allowable
+characters in Section [[[#did-syntax]]] which makes this requirement clear; the
+syntax does not include the `?` character nor the `#` character. This is in
+contrast to identifiers used in a [=DID document=] to identify a [=verification
+method=] or a [=service=], which follow the syntax rules in Section
+[[[#did-url-syntax]]], which does allow the use of query parameters and fragment
+identifiers. Even so, the use of query parameters in long-lived canonical
+identifiers used in [=DID=] ecosystems is discouraged as it can increase the
+complexity of [=DID resolution=] software and potentially lead to a larger
+security attack surface. Fragment identifiers are also expected to be unique
+within a particular [=DID document=] and are discouraged from being re-used
+across time to refer to different [=resources=], such as two different
+[=verification methods=] within the same [=DID document=].
+        </p>
+      </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1590,20 +1590,20 @@ DIDs as defined in Section [[[#did-syntax]]]. The process of authorizing a
         <h3>Identifier Restrictions</h3>
         <p>
 Identifiers used in a [=DID document=] to identify a [=DID subject=] or a [=DID
-Controller=] do not allow the use of query parameters or fragment identifiers.
+Controller=] cannot use query parameters or fragment identifiers.
 Implementers are urged to pay particular attention to the list of allowable
 characters in Section [[[#did-syntax]]] which makes this requirement clear; the
 syntax does not include the `?` character nor the `#` character. This is in
 contrast to identifiers used in a [=DID document=] to identify a [=verification
 method=] or a [=service=], which follow the syntax rules in Section
-[[[#did-url-syntax]]], which does allow the use of query parameters and fragment
+[[[#did-url-syntax]]], which do allow the use of query parameters and fragment
 identifiers. Even so, the use of query parameters in long-lived canonical
-identifiers used in [=DID=] ecosystems is discouraged as it can increase the
+identifiers made for [=DID=] ecosystems is discouraged as it can increase the
 complexity of [=DID resolution=] software and potentially lead to a larger
 security attack surface. Fragment identifiers are also expected to be unique
-within a particular [=DID document=] and are discouraged from being re-used
-across time to refer to different [=resources=], such as two different
-[=verification methods=] within the same [=DID document=].
+within a particular [=DID document=] and implementers are discouraged from
+reusing them to refer to different [=resources=] over time, such as two
+different [=verification methods=] within the same [=DID document=].
         </p>
       </section>
 


### PR DESCRIPTION
This PR is an attempt to address issue #337 by clarifying specific existing (and presumed) restrictions on DID Document identifiers (such as parameters and fragment identifiers).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/886.html" title="Last updated on Apr 3, 2025, 11:56 PM UTC (cc33250)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/886/ffc61ef...cc33250.html" title="Last updated on Apr 3, 2025, 11:56 PM UTC (cc33250)">Diff</a>