### PR TITLE
Simplify abstract data model and specify one concrete representation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1240,9 +1240,9 @@ interpreted in the same way across non-JSON [=representations=].
 
         <p>
 Additional semantics for fragment identifiers, which are compatible with and
-layered upon the semantics in this section, are described for JSON-LD
-representations in [[[#application-did]]]. For information
-about how to dereference a [=DID fragment=], see [[?DID-RESOLUTION]].
+layered upon the semantics in this section, are specified in the media type
+description (see Section [[[#application-did]]]). For information about how to
+dereference a [=DID fragment=], see the [[[?DID-RESOLUTION]]] specification.
         </p>
 
       </section>
@@ -2461,7 +2461,7 @@ according to the rules specified in the [[[JSON-LD11]]] specification.
         </p>
 
         <dl>
-          <dt><dfn>@context</dfn></dt>
+          <dt>@context</dt>
           <dd>
 The <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD Context</a>
 is either a <a data-cite="INFRA#string">string</a> or a <a

--- a/index.html
+++ b/index.html
@@ -2437,17 +2437,18 @@ report an error.
       </section>
 
       <section>
-        <h2>Generalized JSON-LD Processors</h2>
+        <h2>JSON-LD Processors</h2>
 
         <p>
 [[JSON-LD11|JSON-LD]] is a JSON-based format used to serialize
 <a href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>. Some
-implementations are expected to process [=DID documents=] using generalized
-JSON-LD Processing algorithms, so, to maximize interoperability, implementers are
-strongly advised to ensure that general JSON-LD Processing is not prevented. The
-semantics of a [=DID document=] are the same whether general JSON-LD Processing
-is performed or not. Any difference in semantics is an error in either
-implementation or DID Method specification.
+implementations are expected to process [=DID documents=] using the standard
+JSON-LD Processing algorithms, so, to maximize interoperability, implementers
+are strongly advised to ensure that JSON-LD Processing using standards-compliant
+libraries is not prevented. The semantics of a [=DID document=] are the same
+whether JSON-LD Processing using standards-compliant libraries is performed or
+not. Any difference in semantics is an error in either implementation or DID
+Method specification.
         </p>
 
         <p>
@@ -2466,28 +2467,23 @@ maps</a>.
         </dd>
       </dl>
 
-      <section>
-        <h3>Production</h3>
-
-        <p>
+      <p>
 The [=DID document=], DID document data structures, and
 [=representation-specific entries=] <a data-cite="INFRA#maps">map</a> MUST
-be serialized to the JSON-LD [=representation=] according to the JSON
+be serialized to the JSON [=representation=] according to the JSON
 [=representation=] [=production=] rules as defined in [[[#json]]].
         </p>
 
         <p>
 In addition to using the JSON [=representation=] [=production=] rules,
-JSON-LD production MUST include the
-<a data-lt="representation-specific entry">representation-specific</a>
+production MUST include the
 `@context` entry. The serialized value of
 `@context` MUST be the <a data-cite="RFC8259#section-7">JSON
 String</a> `https://www.w3.org/ns/did/v1.1`, or a <a
 data-cite="RFC8259#section-5">JSON Array</a> where the first item is the <a
 data-cite="RFC8259#section-7">JSON String</a>
 `https://www.w3.org/ns/did/v1.1` and the subsequent items are
-serialized according to the JSON [=representation=] [=production=]
-rules.
+serialized according to the JSON [=production=] rules.
         </p>
 
         <pre class="example"
@@ -2529,8 +2525,6 @@ unknown terms. When serializing a JSON-LD [=representation=] of a [=DID
 document=], a [=conforming producer=] MUST specify a media type of
 `application/did` to downstream applications.
         </p>
-
-      </section>
 
         <p>
 [=Conforming consumers=] that process a JSON-LD [=representation=] SHOULD

--- a/index.html
+++ b/index.html
@@ -2443,7 +2443,7 @@ report an error.
 [[JSON-LD11|JSON-LD]] is a JSON-based format used to serialize
 <a href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>. Some
 implementations are expected to process [=DID documents=] using the standard
-JSON-LD Processing algorithms, so, to maximize interoperability, implementers
+JSON-LD Processing algorithms. To maximize interoperability, implementers
 are strongly advised to ensure that JSON-LD Processing using standards-compliant
 libraries is not prevented. The semantics of a [=DID document=] are the same
 whether JSON-LD Processing using standards-compliant libraries is performed or

--- a/index.html
+++ b/index.html
@@ -1922,12 +1922,10 @@ href="#data-model">data model</a> through a process called
 href="#data-model">data model</a> through a process called
 <dfn>consumption</dfn>. The <em>production</em> and <em>consumption</em>
 processes enable the conversion of information from one [=representation=] to
-another. This specification defines a [=representation=] for JSON, which is
-also compatible with processors that perform JSON-LD processing. Developers can
-use any other [=representation=], such as CBOR or YAML, that is capable of
-expressing the <a href="#data-model">data model</a>. The following sections
-define the general rules for [=production=] and [=consumption=], as well as the
-JSON [=representation=].
+another. This specification defines a single [=representation=] for JSON, which
+is also compatible with processors that perform JSON-LD processing. The
+following sections define the general rules for [=production=] and
+[=consumption=], as well as the JSON [=representation=].
     </p>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1436,12 +1436,12 @@ A value that is used to indicate the lack of a value as defined in the [[[INFRA]
 As a result of the <a href="#data-model">data model</a> being defined using
 terminology from the [[[INFRA]]], property values which can contain more than
 one item, such as <a data-cite="INFRA#list">lists</a>, <a
-data-cite="INFRA#ordered-map">maps</a> and <a
+data-cite="INFRA#ordered-map">maps</a>, and <a
 data-cite="INFRA#ordered-set">sets</a>, are explicitly ordered. All list-like
 value structures in the [[[INFRA]]] are ordered, whether or not that order is
-significant. For the purposes of this specification, unless otherwise stated, <a
-data-cite="INFRA#ordered-map">map</a> and <a
-data-cite="INFRA#ordered-set">set</a> ordering is not important and
+significant. For the purposes of this specification, unless otherwise stated,
+ordering of a <a data-cite="INFRA#ordered-map">map</a> or <a
+data-cite="INFRA#ordered-set">set</a> is not important and
 implementations are not expected to produce or consume deterministically ordered
 values.
     </p>
@@ -1464,7 +1464,7 @@ that do not require the use of the [[[?DID-EXTENSIONS]]] repository. Such
 extension mechanisms SHOULD support lossless conversion into any other
 conformant [=representation=]. Extension mechanisms for a [=representation=]
 SHOULD define a mapping of all properties and [=representation=] syntax into the
-<a href="#data-model">data model</a> and its type system.
+[=DID document=] <a href="#data-model">data model</a> and its type system.
       </li>
       </ol>
       <p class="note" title="Unregistered extensions are less reliable">
@@ -1925,7 +1925,7 @@ href="#data-model">data model</a> through a process called
 <dfn>consumption</dfn>. The <em>production</em> and <em>consumption</em>
 processes enable the conversion of information from one [=representation=] to
 another. This specification defines a [=representation=] for JSON, which is
-compatible with processors that also perform JSON-LD processing. Developers can
+also compatible with processors that perform JSON-LD processing. Developers can
 use any other [=representation=], such as CBOR or YAML, that is capable of
 expressing the <a href="#data-model">data model</a>. The following sections
 define the general rules for [=production=] and [=consumption=], as well as the
@@ -2448,11 +2448,11 @@ report an error.
 [[JSON-LD11|JSON-LD]] is a JSON-based format used to serialize
 <a href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>. Some
 implementations are expected to process [=DID documents=] using generalized
-JSON-LD Processing algorithms and so implementers are strongly advised to ensure
-general JSON-LD Processing is not prevented in order to maximize
-interoperability. The semantics of a [=DID document=] are the same whether
-general JSON-LD Processing is performed or not. Any difference in semantics is
-an implementation or DID Method specification error.
+JSON-LD Processing algorithms, so, to maximize interoperability, implementers are
+strongly advised to ensure that general JSON-LD Processing is not prevented. The
+semantics of a [=DID document=] are the same whether general JSON-LD Processing
+is performed or not. Any difference in semantics is an error in either 
+implementation or DID Method specification.
         </p>
 
         <p>
@@ -2514,14 +2514,14 @@ rules.
         </pre>
 
         <p class="advisement" title="JSON-LD serialization rules">
-All implementers creating [=conforming producers=] that produce or consume
+All implementers creating [=conforming processors=] that produce or consume
 [=representations=] meant to be processed as JSON-LD are advised to ensure that
-their algorithms are valid [[JSON-LD11|JSON-LD]] documents. Invalid JSON-LD
+their algorithms produce valid [[JSON-LD11|JSON-LD]] documents. Invalid JSON-LD
 documents will cause JSON-LD processors to halt and report errors.
         </p>
 
         <p>
-In order to achieve interoperability across different [=representations=],
+To achieve interoperability across different [=representations=],
 all JSON-LD Contexts and their terms SHOULD be registered in the repository of
 [[[?DID-EXTENSIONS]]].
         </p>

--- a/index.html
+++ b/index.html
@@ -1917,18 +1917,19 @@ specification for a description of [=services=].
     <h1>Representations</h1>
 
     <p>
-A concrete serialization of a [=DID document=] in this specification is
-called a [=representation=]. A [=representation=] is created by
-serializing the <a href="#data-model">data model</a> through a process called
+A concrete serialization of a [=DID document=] in this specification is called a
+[=representation=]. A [=representation=] is created by serializing the <a
+href="#data-model">data model</a> through a process called
 <dfn>production</dfn>. A [=representation=] is transformed into the <a
 href="#data-model">data model</a> through a process called
 <dfn>consumption</dfn>. The <em>production</em> and <em>consumption</em>
 processes enable the conversion of information from one [=representation=] to
-another. This specification defines [=representations=] for JSON and JSON-LD,
-and developers can use any other [=representation=], such as XML or
-YAML, that is capable of expressing the <a href="#data-model">data model</a>.
-The following sections define the general rules for [=production=] and
-[=consumption=], as well as the JSON and JSON-LD [=representations=].
+another. This specification defines a [=representation=] for JSON, which is
+compatible with processors that also perform JSON-LD processing. Developers can
+use any other [=representation=], such as CBOR or YAML, that is capable of
+expressing the <a href="#data-model">data model</a>. The following sections
+define the general rules for [=production=] and [=consumption=], as well as the
+JSON [=representation=].
     </p>
 
     <section>
@@ -2102,7 +2103,7 @@ one blue arrow pointing from the grey-outlined rectangle to the respective
 black-outlined rectangle, labeled "produce", and one red arrow pointing in the
 reverse direction, labeled "consume". The black-outlined rectangle in the upper
 right is labeled "application/did+cbor", and contains hexadecimal data. The
-rectangle in the lower right is labeled "application/did+json", and contains
+rectangle in the lower right is labeled "application/did", and contains
 the following JSON data:
         </p>
         <pre>
@@ -2120,7 +2121,7 @@ the following JSON data:
 }
         </pre>
         <p>
-The rectangle in the lower left is labeled "application/did+ld+json", and
+The rectangle in the lower left is labeled "application/did", and
 contains the following JSON-LD data:
         </p>
         <pre>
@@ -2282,13 +2283,14 @@ All entries of a [=DID document=] MUST be included in the root <a
 data-cite="RFC8259#section-4">JSON Object</a>. Entries MAY contain additional
 data substructures subject to the value representation rules in the list above.
 When serializing a [=DID document=], a [=conforming producer=] MUST
-specify a media type of `application/did+json` to downstream
+specify a media type of `application/did` to downstream
 applications.
         </p>
 
       <pre class="example nohighlight"
         title="Example DID document in JSON representation">
 {
+  "@context": "https://www.w3.org/ns/did/v1.1",
   "id": "did:example:123456789abcdefghi",
   "authentication": [{
     "id": "did:example:123456789abcdefghi#keys-1",
@@ -2428,7 +2430,7 @@ JSON [[RFC8259]] specification.
 
         <p>
 If media type information is available to a [=conforming consumer=] and the
-media type value is `application/did+json`, then the data structure
+media type value is `application/did`, then the data structure
 being consumed is a [=DID document=], and the root element MUST be a <a
 data-cite="RFC8259#section-4">JSON Object</a> where all members of the object
 are entries of the [=DID document=]. A [=conforming consumer=] for a JSON
@@ -2438,26 +2440,29 @@ report an error.
         </p>
 
       </section>
-    </section>
 
-    <section>
-      <h2>JSON-LD</h2>
+      <section>
+        <h2>JSON-LD Processing</h2>
 
-      <p>
-JSON-LD [[JSON-LD11]] is a JSON-based format used to serialize <a
-href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>. This
-section defines the [=production=] and [=consumption=] rules for the
-JSON-LD [=representation=].
-      </p>
+        <p>
+[[JSON-LD11|JSON-LD]] is a JSON-based format used to serialize
+<a href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>. Some
+implementations are expected to process [=DID documents=] using JSON-LD
+Processing algorithms and so implementers are strongly advised to ensure JSON-LD
+Processing is not prevented in order to maximize interoperability. The semantics
+of a [=DID document=] are the same whether JSON-LD Processing is performed or
+not. Any difference in semantics is an implementation or DID Method
+specification error.
+        </p>
 
-      <p>
-The JSON-LD [=representation=] defines the following
-[=representation-specific entries=]:
-      </p>
+        <p>
+For JSON-LD processing to occur, a `@context` property MUST be specified
+according to the rules specified in the [[[JSON-LD11]]] specification.
+        </p>
 
-      <dl>
-        <dt><dfn>@context</dfn></dt>
-        <dd>
+        <dl>
+          <dt><dfn>@context</dfn></dt>
+          <dd>
 The <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD Context</a>
 is either a <a data-cite="INFRA#string">string</a> or a <a
 data-cite="INFRA#list">list</a> containing any combination of <a
@@ -2509,16 +2514,16 @@ rules.
         </pre>
 
         <p class="advisement" title="JSON-LD serialization rules">
-All implementers creating [=conforming producers=] that produce JSON-LD
-[=representations=] are advised to ensure that their algorithms
-produce valid JSON-LD [[JSON-LD11]] documents. Invalid JSON-LD documents will
-cause JSON-LD processors to halt and report errors.
+All implementers creating [=conforming producers=] that produce or consume
+[=representations=] meant to be processed as JSON-LD are advised to ensure that
+their algorithms valid [[JSON-LD11|JSON-LD]] documents. Invalid JSON-LD
+documents will cause JSON-LD processors to halt and report errors.
         </p>
 
         <p>
 In order to achieve interoperability across different [=representations=],
 all JSON-LD Contexts and their terms SHOULD be registered in the repository of
-DID Extensions [[?DID-EXTENSIONS]].
+[[[?DID-EXTENSIONS]]].
         </p>
 
         <p>
@@ -2527,27 +2532,10 @@ SHOULD NOT produce a [=DID document=] that contains terms not defined via the
 `@context` as [=conforming consumers=] are expected to remove
 unknown terms. When serializing a JSON-LD [=representation=] of a [=DID
 document=], a [=conforming producer=] MUST specify a media type of
-`application/did+ld+json` to downstream applications.
+`application/did` to downstream applications.
         </p>
 
       </section>
-
-      <section>
-        <h3>Consumption</h3>
-
-        <p>
-The [=DID document=] and any DID document data structures expressed by a
-JSON-LD [=representation=] MUST be deserialized into the <a
-href="#data-model">data model</a> according to the JSON [=representation=]
-[=consumption=] rules as defined in [[[#json]]].
-        </p>
-
-        <p class="advisement" title="JSON-LD serialization rules">
-All implementers creating [=conforming consumers=] that consume JSON-LD
-[=representations=] are advised to ensure that their algorithms only accept
-valid JSON-LD [[JSON-LD11]] documents. Invalid JSON-LD documents will cause
-JSON-LD processors to halt and report errors.
-        </p>
 
         <p>
 [=Conforming consumers=] that process a JSON-LD [=representation=] SHOULD
@@ -4444,7 +4432,7 @@ Recommendation</a> include:
       <li>
 Addition of at risk markers to most of the DID Parameters, the data model
 datatypes that are expected to not be implemented, and the
-application/did+ld+json media type. This change resulted in the DID WG's
+application/did media type. This change resulted in the DID WG's
 decision to perform a second Candidate Recommendation phase. All other
 changes were either editorial or predicted in "at risk" issue markers.
       </li>

--- a/index.html
+++ b/index.html
@@ -1311,63 +1311,23 @@ an absolute [=DID URL=] value of
     <h1>Data Model</h1>
     <p>
 This specification defines a data model that can be used to express [=DID
-documents=] and DID document data structures, which can then be serialized
-into multiple concrete [=representations=]. This section provides a
-high-level description of the data model, descriptions of the ways different
-types of properties are expressed in the data model, and instructions for
-extending the data model.
+documents=] and their internal data structures, which can then be serialized
+into a concrete expression. This section provides a high-level description of
+the data model, descriptions of the ways different types of properties are
+expressed in the data model, and instructions for extending the data model.
     </p>
     <p>
 A [=DID document=] consists of a <a data-cite="INFRA#maps">map</a> of <a
 data-cite="INFRA#map-entry">entries</a>, where each entry consists of a
-key/value pair. The [=DID document=] data model contains at least two
-different classes of entries. The first class of entries is called properties,
-and is specified in section [[[#core-properties]]]. The second class
-is made up of [=representation-specific entries=], and is specified in
-section [[[#representations]]].
+key/value pair. The [=DID document=] data model contains properties that are
+specified in section [[[#core-properties]]].
     </p>
-
-    <figure id="did-document-entries">
-      <img style="margin: auto; display: block;"
-        src="diagrams/diagram-did-document-entries.svg" alt="
-Diagram illustrating the entries in the DID document, including properties
-and representation-specific entries; some entries are defined by this
-specification; others are defined by registered or unregistered extensions.">
-      <figcaption>
-The entries in a DID document.
-See also: <a class="longdesc-link"
-href="#did-document-entries-longdesc">narrative description</a>.
-      </figcaption>
-    </figure>
-
-    <div class="longdesc" id="did-document-entries-longdesc">
-The diagram is titled, "Entries in the DID Document map". A dotted grey line
-runs horizontally through the center of the diagram. The space above the line
-is labeled "Properties", and the space below it, "Representation-specific
-entries". Six labeled rectangles appear in the diagram, three lying above the
-dotted grey line and three below it. A large green rectangle, labeled "DID
-Extensions", encloses the four leftmost rectangles (upper left,
-upper center, lower left, and lower center). The two leftmost rectangles
-(upper left and lower left) are outlined in blue and labeled in blue, as
-follows. The upper left rectangle is labeled "Core Properties", and contains
-text "id, alsoKnownAs, controller, authentication, verificationMethod, service,
-serviceEndpoint, ...". The lower left rectangle is labeled "Core
-Representation-specific Entries", and contains text "@context". The four
-rightmost rectangles (upper center, upper right, lower center, and lower right)
-are outlined in grey and labeled in black, as follows. The upper center
-rectangle is labeled, "Property Extensions", and contains text
-"ethereumAddress". The lower center rectangle is labeled,
-"Representation-specific Entry Extensions", and contains no other text. The
-upper right rectangle is labeled, "Unregistered Property Extensions", and
-contains text "foo". The lower right rectangle is labeled "Unregistered
-Representation-specific Entry Extensions", and contains text "%YAML, xmlns".
-    </div>
 
     <p>
 All entry keys in the [=DID document=] data model are <a
 data-cite="INFRA#strings">strings</a>. All entry values are expressed using one
-of the abstract data types in the table below, and each [=representation=]
-specifies the concrete serialization format of each data type.
+of the data types in the table below, and each [=representation=] specifies the
+concrete serialization format of each data type.
     </p>
 
     <table class="simple" id="data-types">
@@ -1389,8 +1349,8 @@ Considerations
           </td>
           <td>
 A finite ordered sequence of key/value pairs, with no key appearing twice as
-specified in [[INFRA]]. A map is sometimes referred to as an
-<a data-cite="INFRA#maps">ordered map</a> in [[INFRA]].
+specified in the [[[INFRA]]]. A map is sometimes referred to as an
+<a data-cite="INFRA#maps">ordered map</a> in the [[[INFRA]]].
           </td>
         </tr>
         <tr>
@@ -1398,7 +1358,7 @@ specified in [[INFRA]]. A map is sometimes referred to as an
 <a data-cite="INFRA#list">list</a>
           </td>
           <td>
-A finite ordered sequence of items as specified in [[INFRA]].
+A finite ordered sequence of items as specified in the [[[INFRA]]].
           </td>
         </tr>
         <tr>
@@ -1407,8 +1367,8 @@ A finite ordered sequence of items as specified in [[INFRA]].
           </td>
           <td>
 A finite ordered sequence of items that does not contain the same item twice
-as specified in [[INFRA]]. A set is sometimes referred to as an
-<a data-cite="INFRA#ordered-set">ordered set</a> in [[INFRA]].
+as specified in the [[[INFRA]]]. A set is sometimes referred to as an
+<a data-cite="INFRA#ordered-set">ordered set</a> in the [[[INFRA]]].
           </td>
         </tr>
         <tr>
@@ -1417,8 +1377,8 @@ as specified in [[INFRA]]. A set is sometimes referred to as an
           </td>
           <td>
 A date and time value that is capable of losslessly expressing all values
-expressible by a `dateTime` as specified in
-[<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>].
+expressible by a <a data-cite="XMLSCHEMA11-2#dateTime">dateTime</a> as
+specified in [[XMLSCHEMA11-2]].
           </td>
         </tr>
         <tr>
@@ -1427,7 +1387,7 @@ expressible by a `dateTime` as specified in
           </td>
           <td>
 A sequence of code units often used to represent human readable language
-as specified in [[INFRA]].
+as specified in the [[[INFRA]]].
           </td>
         </tr>
         <tr>
@@ -1435,10 +1395,10 @@ as specified in [[INFRA]].
 <dfn>integer</dfn>
           </td>
           <td>
-A real number without a fractional component as specified in
-[<a data-cite="XMLSCHEMA11-2#decimal">XMLSCHEMA11-2</a>]. To maximize
-interoperability, implementers are urged to heed the advice regarding
-integers in <a data-cite="rfc8259#section-6">RFC8259, Section 6: Numbers</a>.
+A <a data-cite="XMLSCHEMA11-2#decimal">real number without a fractional
+component</a> as specified in [[XMLSCHEMA11-2]]. To maximize interoperability,
+implementers are urged to heed the advice regarding integers in
+<a data-cite="rfc8259#section-6">RFC8259, Section 6: Numbers</a>.
           </td>
         </tr>
         <tr>
@@ -1446,10 +1406,11 @@ integers in <a data-cite="rfc8259#section-6">RFC8259, Section 6: Numbers</a>.
 <dfn>double</dfn>
           </td>
           <td>
-A value that is often used to approximate arbitrary real numbers as specified
-in [<a data-cite="XMLSCHEMA11-2#double">XMLSCHEMA11-2</a>]. To maximize
-interoperability, implementers are urged to heed the advice regarding
-doubles in <a data-cite="rfc8259#section-6">RFC8259, Section 6: Numbers</a>.
+A <a data-cite="XMLSCHEMA11-2#double">real number with a fractional
+component</a> that is often used to approximate arbitrary real numbers as
+specified in [[XMLSCHEMA11-2]]. To maximize interoperability, implementers are
+urged to heed the advice regarding doubles in
+<a data-cite="rfc8259#section-6">RFC8259, Section 6: Numbers</a>.
           </td>
         </tr>
         <tr>
@@ -1457,7 +1418,7 @@ doubles in <a data-cite="rfc8259#section-6">RFC8259, Section 6: Numbers</a>.
 <a data-cite="INFRA#boolean">boolean</a>
           </td>
           <td>
-A value that is either true or false as defined in [[INFRA]].
+A value that is either true or false as defined in the [[[INFRA]]].
           </td>
         </tr>
         <tr>
@@ -1465,7 +1426,7 @@ A value that is either true or false as defined in [[INFRA]].
 <a data-cite="INFRA#nulls">null</a>
           </td>
           <td>
-A value that is used to indicate the lack of a value as defined in [[INFRA]].
+A value that is used to indicate the lack of a value as defined in the [[[INFRA]]].
           </td>
         </tr>
       </tbody>
@@ -1473,11 +1434,11 @@ A value that is used to indicate the lack of a value as defined in [[INFRA]].
 
     <p class="advisement" title="Ordering of values">
 As a result of the <a href="#data-model">data model</a> being defined using
-terminology from [[INFRA]], property values which can contain more than one
-item, such as <a data-cite="INFRA#list">lists</a>, <a
+terminology from the [[[INFRA]]], property values which can contain more than
+one item, such as <a data-cite="INFRA#list">lists</a>, <a
 data-cite="INFRA#ordered-map">maps</a> and <a
 data-cite="INFRA#ordered-set">sets</a>, are explicitly ordered. All list-like
-value structures in [[INFRA]] are ordered, whether or not that order is
+value structures in the [[[INFRA]]] are ordered, whether or not that order is
 significant. For the purposes of this specification, unless otherwise stated, <a
 data-cite="INFRA#ordered-map">map</a> and <a
 data-cite="INFRA#ordered-set">set</a> ordering is not important and
@@ -1493,26 +1454,24 @@ The data model supports two types of extensibility.
       <ol>
         <li>
 For maximum interoperability, it is RECOMMENDED that extensions use the
-repository of DID Extensions [[?DID-EXTENSIONS]]. The use of
-this mechanism for new properties or other extensions is the only specified
-mechanism that ensures that two different [=representations=] will be able to
-work together.
+repository of [[[?DID-EXTENSIONS]]]. The use of this mechanism for new
+properties or other extensions is the only specified mechanism that ensures that
+two different [=representations=] will be able to work together.
         </li>
       <li>
 [=Representations=] MAY define other extensibility mechanisms, including ones
-that do not require the use of the DID Extensions. Such extension
-mechanisms SHOULD support lossless conversion into any other conformant
-[=representation=]. Extension mechanisms for a [=representation=] SHOULD
-define a mapping of all properties and [=representation=] syntax into the <a
-href="#data-model">data model</a> and its type system.
+that do not require the use of the [[[?DID-EXTENSIONS]]] repository. Such
+extension mechanisms SHOULD support lossless conversion into any other
+conformant [=representation=]. Extension mechanisms for a [=representation=]
+SHOULD define a mapping of all properties and [=representation=] syntax into the
+<a href="#data-model">data model</a> and its type system.
       </li>
       </ol>
       <p class="note" title="Unregistered extensions are less reliable">
 It is always possible for two specific implementations to agree out-of-band to
-use a mutually understood extension or [=representation=] that is not
-recorded in the repository of DID Extensions [[?DID-EXTENSIONS]];
-interoperability between such implementations and the larger ecosystem will be
-less reliable.
+use a mutually understood extension or [=representation=] that is not recorded
+in the repository of [[[?DID-EXTENSIONS]]]; interoperability between such
+implementations and the larger ecosystem will be less reliable.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -2442,17 +2442,17 @@ report an error.
       </section>
 
       <section>
-        <h2>JSON-LD Processing</h2>
+        <h2>Generalized JSON-LD Processors</h2>
 
         <p>
 [[JSON-LD11|JSON-LD]] is a JSON-based format used to serialize
 <a href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>. Some
-implementations are expected to process [=DID documents=] using JSON-LD
-Processing algorithms and so implementers are strongly advised to ensure JSON-LD
-Processing is not prevented in order to maximize interoperability. The semantics
-of a [=DID document=] are the same whether JSON-LD Processing is performed or
-not. Any difference in semantics is an implementation or DID Method
-specification error.
+implementations are expected to process [=DID documents=] using generalized
+JSON-LD Processing algorithms and so implementers are strongly advised to ensure
+general JSON-LD Processing is not prevented in order to maximize
+interoperability. The semantics of a [=DID document=] are the same whether
+general JSON-LD Processing is performed or not. Any difference in semantics is
+an implementation or DID Method specification error.
         </p>
 
         <p>
@@ -2516,7 +2516,7 @@ rules.
         <p class="advisement" title="JSON-LD serialization rules">
 All implementers creating [=conforming producers=] that produce or consume
 [=representations=] meant to be processed as JSON-LD are advised to ensure that
-their algorithms valid [[JSON-LD11|JSON-LD]] documents. Invalid JSON-LD
+their algorithms are valid [[JSON-LD11|JSON-LD]] documents. Invalid JSON-LD
 documents will cause JSON-LD processors to halt and report errors.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1003,9 +1003,7 @@ information describing a [=DID subject=]. See <a href="#representations"></a>.
       <dd>
 Entries in a [=DID document=] whose meaning is particular to a specific
 [=representation=]. Defined in <a href="#data-model"></a> and
-<a href="#representations"></a>. For example, <a><code>@context</code></a> in
-the <a href="#json-ld">JSON-LD representation</a> is a
-<em>representation-specific entry</em>.
+<a href="#representations"></a>.
       </dd>
 
       <dt><dfn>service</dfn></dt>
@@ -2419,10 +2417,9 @@ A <a data-cite="INFRA#nulls">null</a> value.
         </table>
 
         <p class="advisement">
-All implementers creating [=conforming consumers=] that produce JSON
-[=representations=] are advised to ensure that their algorithms are aligned
-with the <a
-data-cite="INFRA#parse-json-bytes-to-an-infra-value">JSON
+All implementers creating [=conforming producers=] or [=conforming consumers=]
+are advised to ensure that their algorithms are aligned with the
+<a data-cite="INFRA#parse-json-bytes-to-an-infra-value">JSON
 conversion rules</a> in the [[INFRA]] specification and the <a
 data-cite="RFC8259#section-6">precision advisements regarding Numbers</a> in the
 JSON [[RFC8259]] specification.
@@ -2451,7 +2448,7 @@ implementations are expected to process [=DID documents=] using generalized
 JSON-LD Processing algorithms, so, to maximize interoperability, implementers are
 strongly advised to ensure that general JSON-LD Processing is not prevented. The
 semantics of a [=DID document=] are the same whether general JSON-LD Processing
-is performed or not. Any difference in semantics is an error in either 
+is performed or not. Any difference in semantics is an error in either
 implementation or DID Method specification.
         </p>
 
@@ -2514,7 +2511,7 @@ rules.
         </pre>
 
         <p class="advisement" title="JSON-LD serialization rules">
-All implementers creating [=conforming processors=] that produce or consume
+All implementers creating [=conforming consumers=] that produce or consume
 [=representations=] meant to be processed as JSON-LD are advised to ensure that
 their algorithms produce valid [[JSON-LD11|JSON-LD]] documents. Invalid JSON-LD
 documents will cause JSON-LD processors to halt and report errors.


### PR DESCRIPTION
This PR is an attempt to address issue #855 by simplifying the abstract data model down to INFRA and specifying a single concrete JSON representation. 

Note: We are currently in maintenance mode, which means that we cannot make any class 4 changes (change normative statements in ways that are not backwards compatible). That has hampered a more straightforward PR and required some normative acrobatics given that I couldn't remove previous normative statements. Please keep this in mind as you review as some wording is painfully contrived due to our maintenance mode status with this specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/887.html" title="Last updated on Apr 24, 2025, 1:47 PM UTC (42d0bd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/887/2022960...42d0bd1.html" title="Last updated on Apr 24, 2025, 1:47 PM UTC (42d0bd1)">Diff</a>