### PR TITLE
re-enable Echidna

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,11 +9,11 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
-          W3C_WG_DECISION_URL: https://www.w3.org/2019/did-wg/Meetings/Minutes/2019-10-22-did#resolution1
+          W3C_WG_DECISION_URL: https://www.w3.org/2024/09/24-did-minutes.html#r02
           W3C_BUILD_OVERRIDE: |
-             shortName: did-core
-             specStatus: CRD
+             shortName: did-1.1
+             specStatus: WD


### PR DESCRIPTION
I realize that Echidna was never re-enabled since we published our FPWD. This should no the trick.