### PR TITLE
Added the necessary files for vocabulary deployment

### DIFF
--- a/.github/workflows/vocabulary.yml
+++ b/.github/workflows/vocabulary.yml
@@ -1,0 +1,55 @@
+# Relies on the standard GitHub action setup to deploy to GitHub Pages
+# The really specific details are in the steps that generates the vocabulary files
+# (and the deployment of deno as an underling tool).
+# See https://github.com/w3c/yml2vocab for more details
+#
+# Note that for this script to work, the repository setting for GitHub pages must be changed!
+name: Generate the vocabulary files and publish to Github Pages
+on:
+  push:
+    branches: [main]
+    paths: ['vocab/v11/**']
+  # Allows workflow to be triggered manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout/@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Generate the vocabulary files
+        # Run the yml2vocab script
+        # As a result, the following files will be available on w3c.github.io/vocab/v11
+        # - vocabulary.{html,ttl,jsonld}:  Vocab in HTML/RDFa, Turtle, and JSON-LD, respectively
+        # - vocabulary.context.jsonld: JSON-LD context file for the full vocabulary, including external terms
+        run: |
+          (cd vocab/v11; deno run -A jsr:@iherman/yml2vocab/cli -t template.html -v vocabulary.yml -c)
+      - name: Setup Github Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vocab/v11/template.html
+++ b/vocab/v11/template.html
@@ -1,0 +1,219 @@
+<html lang="en">
+  <head>
+    <meta charset='utf-8'/>
+    <title></title>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+    <script>
+      function remove_status_remark() {
+          const sotd = document.getElementById("sotd");
+          const p = sotd.getElementsByTagName('p')[0];
+          sotd.removeChild(p);
+      }
+      // Note: The vocabulary URL must be adapted for the given environment!!!!
+      function massageSVGLinks(utils, content, url) {
+        const retval = content
+          .replace('<svg', '<svg aria-details="#vocabulary-diagram-alt" ')
+          .replace(/xlink:href/g, 'href')
+          .replace(/href="https:\/\/w3id.org\/security#/g, 'href="#');
+        return retval;
+      }
+    </script>
+    <script class="remove">
+      var respecConfig = {
+        localBiblio: {
+        },
+        specStatus:  "base",
+        shortName:   "ns/did",
+        thisVersion: "https://w3c.github.io/did/vocab/vocabulary.html",
+        latestVersion: "https://www.w3.org/TR/did-1.1/",
+        doJsonLd:    true,
+        editors: [{
+          name:       "Ivan Herman",
+          url:        "https://www.w3.org/People/Ivan/",
+          company:    "W3C",
+          w3cid:      7382,
+          orcid:      "0000-0003-0782-2704",
+          companyURL: "https://www.w3.org",
+        },{
+          name:       "Manu Sporny",
+          url:        "http://manu.sporny.org/",
+          company:    "Digital Bazaar",
+          companyURL: "http://digitalbazaar.com/",
+          w3cid:      41758,
+        }],
+        alternateFormats: [
+          {uri: "vocabulary.ttl", label: "Turtle"},
+          {uri: "vocabulary.jsonld", label: "JSON-LD"}
+        ],
+        inlineCSS: true,
+        doRDFa: false,
+        noIDLIn: true,
+        noLegacyStyle: false
+      };
+    </script>
+    <style type="text/css">
+      dl.terms dt {
+        float: left;
+        clear: left;
+        width: 10vw;
+      }
+
+      dl.terms dd {
+        margin-left: 15vw;
+      }
+
+      dl.terms dd:after {
+          content: '';
+          display: block;
+          clear: both;
+          margin-bottom: 5px;
+      }
+      table.rdfs-definition td {
+        vertical-align: top;
+        margin-right: 2em;
+      }
+      .bold {
+        font-weight: bold;
+      }
+      /* code {
+        color: red;
+      } */
+
+      .term_definitions section {
+        border-bottom-style: solid ;
+        border-bottom-width: 1px;
+        border-bottom-color: darkgrey;
+      }
+
+      .annoy {
+        background: hsla(40,100%,50%,0.95);
+		    color: black;
+		    padding: .75em 1em;
+		    border: red;
+		    border-style: solid none;
+		    box-shadow: 0 2px 8px black;
+		    text-align: center;
+      }
+
+      summary {
+        font-weight: normal !important;
+      }
+
+    </style>
+  </head>
+  <body  typeof="owl:Ontology">
+    <section id="abstract">
+      <p>This document describes the <span property="dc:title" id="title"></span>, i.e.,
+         the <span property="dc:description" id="description">.</span>
+      </p>
+      <p>Alternate versions of the vocabulary definition exist in
+        <a rel="alternate" href="vocabulary.ttl">Turtle</a> and
+        <a rel="alternate" href="vocabulary.jsonld">JSON-LD</a>.
+      </p>
+      <dl>
+        <dt>Published:</dt><dd><time property="dc:date" id="time"></time></dd>
+        <dt>Version Info:</dt>
+        <dd>1.1</dd>
+        <dt id="see_also">See Also: </dt>
+       </dl>
+    </section>
+    <section id="sotd">
+      <p>
+        Comments regarding this document are welcome. Please file issues
+        directly on <a href="https://github.com/w3c/did/issues/">GitHub</a>, or send them to
+        <a href="mailto:public-did-wg@w3.org">mailto:public-did-wg@w3.org</a>
+        (<a href="mailto:public-did-wg@w3.org?subject=subscribe">subscribe</a>,
+        <a href="https://lists.w3.org/Archives/Public/public-did-wg">archives</a>).
+      </p>
+    </section>
+
+    <section>
+      <h2>Namespaces</h2>
+      <p>This specification makes use a number of external vocabulary namespaces.</p>
+      <details>
+        <summary>Click here for details.</summary>
+        <dl class="terms" id="namespaces">
+        </dl>        
+      </details>
+    </section>
+
+    <section>
+      <h2><code>@context</code> files</h2>
+      <p>Several <code>@context</code> files make use of the terms defined in this specification.</p>
+      <details>
+        <summary>Click here for details.</summary>
+        <ul id="contexts">
+        </ul>
+      </details>
+    </section>
+
+    <section id="term_definitions">
+      <h1>Regular terms</h1>
+
+      <section id="property_definitions" class="term_definitions">
+        <h2>Property definitions</h2>
+      </section>
+
+      <section id="class_definitions" class="term_definitions">
+        <h2>Class definitions</h2>
+      </section>
+  
+      <section id="datatype_definitions" class="term_definitions">
+        <h2>Datatype definitions</h2>
+      </section>
+  
+      <section id="individual_definitions" class="term_definitions">
+        <h2>Definitions for individuals</h2>
+      </section>
+    </section>   
+
+    <section id="reserved_term_definitions">
+      <h1>Reserved terms</h1>
+    
+      <p>All terms in this section are <em><strong>reserved</strong></em>.
+        Implementers may use these properties, but should expect them and/or their meanings to change during the process to
+        normatively specify them.
+      </p>
+    
+      <section id="reserved_property_definitions" class="term_definitions">
+        <h2>Reserved properties</h2>
+      </section>
+
+      <section id="reserved_class_definitions" class="term_definitions">
+        <h2>Reserved classes</h2>
+      </section>
+    
+      <section id="reserved_datatype_definitions" class="term_definitions">
+        <h2>Reserved datatype definitions</h2>
+      </section>
+    
+      <section id="reserved_individual_definitions" class="term_definitions">
+        <h2>Reserved individuals</h2>
+      </section>
+    </section>
+
+    <section id="deprecated_term_definitions">
+      <h1>Deprecated terms</h1>
+
+      <p class="annoy">All terms in this section are <em><strong>deprecated</strong></em>, and are only kept in this vocabulary for backward compatibility. 
+        <br><br>New applications should not use them.
+      </p>
+
+      <section id="deprecated_property_definitions" class="term_definitions">
+        <h2>Deprecated properties</h2>
+      </section>
+
+      <section id="deprecated_class_definitions" class="term_definitions">
+        <h2>Deprecated classes</h2>
+      </section>
+
+      <section id="deprecated_datatype_definitions" class="term_definitions">
+        <h2>Deprecated datatype definitions</h2>
+      </section>
+    
+      <section id="deprecated_individual_definitions" class="term_definitions">
+        <h2>Deprecated individuals</h2>
+      </section>
+    </section>  
+  </body>
+</html>

--- a/vocab/v11/vocabulary.yml
+++ b/vocab/v11/vocabulary.yml
@@ -1,0 +1,201 @@
+vocab:
+  id: dd
+  value: https://www.w3.org/ns/did#
+  context: https://www.w3.org/ns/did/v1.1
+
+prefix:
+  - id: sec
+    value: https://w3id.org/security#
+  - id: act
+    value: https://www.w3.org/ns/activitystreams#
+  
+ontology:
+  - property: dc:title
+    value: DID Vocabulary
+
+  - property: dc:description
+    value: |
+      vocabulary used to ensure the authenticity and integrity of W3C DID Documents, a profile of W3C Controlled Identifier Document.
+
+  - property: rdfs:seeAlso
+    value: https://www.w3.org/TR/did-1.1/
+
+class:
+  # - id: DecentralizedIdentifierDocument
+  #   label: Decentralized Identifier Document
+  #   defined_by: https://www.w3.org/TR/did-1.1/#data-model
+  #   upper_value: sec:ControlledIdentifierDocument
+  #   context: none
+
+  - id: Service
+    label: Service
+    comment: A service is a set of properties that describe a service endpoint, and should be defined through subclasses to this class. In order to maximize interoperability, the service type and its associated properties should be registered in the [[[did-spec-registries]]] [[did-spec-registries]].
+    defined_by: https://www.w3.org/TR/did-1.1/#services
+    context: none
+
+  # - id: sec:ControlledIdentifierDocument
+  #   label: Controlled Identifier Document
+  #   defined_by: https://www.w3.org/TR/cid-1.0/#controlled-identifier-documents
+  #   context: none
+
+  - id: sec:VerificationMethod
+    label: Verification method
+    comment: Instances of this class must be <a href="https://www.w3.org/TR/rdf11-concepts/#resources-and-statements">denoted by URLs</a>, i.e., they cannot be blank nodes.
+    defined_by: https://www.w3.org/TR/cid-1.0/#verification-methods
+    context: none
+
+  - id: sec:VerificationRelationship
+    comment: Instances of this class are verification relationships like, for example, <a href="https://www.w3.org/TR/did-1.1/#authentication">authentication</a> or <a href="https://www.w3.org/TR/did-1.1/#assertion">assertionMethod</a>.
+    defined_by: https://www.w3.org/TR/cid-1.0/#verification-relationships
+    upper_value: rdf:Property
+    context: none
+
+  - id: sec:Multikey
+    label: Multikey Verification Method
+    upper_value: sec:VerificationMethod
+    defined_by: https://www.w3.org/TR/cid-1.0/#multikey
+    context: https://w3id.org/security/multikey/v1
+
+  - id: sec:JsonWebKey
+    label: JSON Web Key Verification Method
+    upper_value: sec:VerificationMethod
+    defined_by: https://www.w3.org/TR/cid-1.0/#jsonwebkey
+    context: https://w3id.org/security/jwk/v1
+
+
+property:
+  - id: sec:controller
+    label: Controller
+    range: IRI
+    defined_by: [https://www.w3.org/TR/cid-1.0/#defn-controller]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#did-controller
+    context: [vocab, https://w3id.org/security/data-integrity/v2, https://www.w3.org/ns/cid/v1]
+
+  - id: act:alsoKnownAs
+    label: Also known as
+    range: xsd:string
+    defined_by: [https://www.w3.org/ns/activitystreams#]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: vocab
+
+  - id: sec:verificationMethod
+    label: Verification method  
+    range: sec:VerificationMethod
+    defined_by: [https://www.w3.org/TR/cid-1.0/#dfn-verificationmethod]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: [vocab, https://w3id.org/security/data-integrity/v2]
+
+  - id: sec:authentication
+    label: Authentication method
+    range: sec:VerificationMethod
+    type: sec:VerificationRelationship
+    defined_by: [hhttps://www.w3.org/TR/cid-1.0/#authentication]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: [vocab, https://w3id.org/security/data-integrity/v2, https://www.w3.org/ns/cid/v1]
+
+  - id: sec:assertionMethod
+    label: Assertion method
+    range: sec:VerificationMethod
+    type: sec:VerificationRelationship
+    defined_by: [https://www.w3.org/TR/cid-1.0/#assertion]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: [vocab, https://w3id.org/security/data-integrity/v2, https://www.w3.org/ns/cid/v1]
+
+  - id: sec:capabilityDelegationMethod
+    label: Capability delegation method
+    range: sec:VerificationMethod
+    type: sec:VerificationRelationship
+    comment: Historically, this property has often been expressed using `capabilityDelegation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityDelegation`) and the property identifier (`...#capabilityDelegationMethod`) is expected and should not trigger an error.
+    defined_by: [https://www.w3.org/TR/cid-1.0/#capability-delegationd]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: [vocab, https://w3id.org/security/data-integrity/v2, https://www.w3.org/ns/cid/v1]
+    known_as: capabilityDelegation
+
+  - id: sec:capabilityInvocationMethod
+    label: Capability invocation method
+    range: sec:VerificationMethod
+    type: sec:VerificationRelationship
+    comment: Historically, this property has often been expressed using `capabilityInvocation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityInvocation`) and the property identifier (`...#capabilityInvocationMethod`) is expected and should not trigger an error.
+    defined_by: [https://www.w3.org/TR/cid-1.0/#capability-invocation]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: [vocab, https://w3id.org/security/data-integrity/v2, https://www.w3.org/ns/cid/v1]
+    known_as: capabilityInvocation
+
+  - id: sec:keyAgreementMethod
+    label: Key agreement protocols
+    type: sec:VerificationRelationship
+    range: sec:VerificationMethod
+    comment: Historically, this property has often been expressed using `keyAgreement` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`keyAgreement`) and the property identifier (`...#keyAgreementMethod`) is expected and should not trigger an error.
+    defined_by: [https://www.w3.org/TR/cid-1.0/#key-agreementd]
+    see_also:
+      - label: DID 1.1 specification
+        url: https://www.w3.org/TR/did-1.1/#core-properties
+    context: [vocab, https://w3id.org/security/data-integrity/v2, https://www.w3.org/ns/cid/v1]
+    known_as: keyAgreement
+
+  - id: sec:publicKeyMultibase
+    label: Public key multibase
+    domain: sec:Multikey
+    range: sec:multibase
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-publickeymultibase
+    context: [vocab, https://w3id.org/security/multikey/v1]
+
+  - id: sec:secretKeyMultibase
+    label: Secret key multibase
+    domain: sec:Multikey
+    range: sec:multibase
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-secretkeymultibase
+    context: [vocab, https://w3id.org/security/multikey/v1]
+
+  - id: sec:publicKeyJwk
+    label: Public key JWK
+    range: rdf:JSON
+    domain: sec:JsonWebKey
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-publickeyjwk
+    context: [vocab, https://w3id.org/security/jwk/v1]
+
+  - id: sec:secretKeyJwk
+    label: Secret key JWK
+    range: rdf:JSON
+    domain: sec:JsonWebKey
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-secretkeyjwk
+    context: [vocab, https://w3id.org/security/jwk/v1]
+
+  - id: service
+    label: Service
+    # domain: dd:DecentralizedIdentifierDocument
+    range: dd:Service
+    comment: The associated value must be a set of services, where each service is described by a map. 
+    defined_by: https://www.w3.org/TR/did-1.1/#services
+    context: vocab
+  
+  - id: serviceEndpoint
+    label: Service endpoint
+    comment: Refers to the service endpoint, which is a URL that can be used to access the service.
+    domain: dd:Service
+    range: IRI
+    defined_by: https://www.w3.org/TR/did-1.1/#services
+    context: vocab
+
+datatype:
+  - id: sec:multibase
+    label: Datatype for multibase values
+    upper_value: xsd:string
+    defined_by: https://www.w3.org/TR/cid-1.0/#multibase
+    context: https://w3id.org/security/multikey/v1
+
+


### PR DESCRIPTION
This is the PR on issue #884. It includes the vocabulary description file in YAML, the HTML template file, and also includes a GitHub action to generate the HTML, Turtle, and JSON-LD files, as well as the `@context` file.

The generated files can be preview-d at https://w3c.github.io/yml2vocab/previews/did/.

More information on the underlying tool can be found at https://github.com/w3c/yml2vocab, with the corresponding package being available on [npm](https://www.npmjs.com/package/yml2vocab) and on [jsr](https://jsr.io/@iherman/yml2vocab).