### PR TITLE
Clarify that relative URLs are allowed for VM identifiers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1868,12 +1868,11 @@ different [=verification methods=] within the same [=DID document=].
     <section>
       <h2>Verification Methods</h2>
       <p>
-A [=DID document=] can express [=verification methods=], as defined in
-<a data-cite="CID#verification-methods">Section 2.2: Verification Methods</a> of
-[[[CID]]] with the added restriction that the `id` value
-MUST conform to the [[[#did-url-syntax]]] and the
-`controller` value MUST conform to the [[[#did-syntax]]].
-See
+A [=DID document=] can express [=verification methods=], as defined in Section
+<a data-cite="CID#verification-methods">2.2: Verification Methods</a> of
+[[[CID]]] with the added restriction that the `id` value MUST conform to Section
+[[[#did-url-syntax]]] or Section [[[#relative-did-urls]]] and the `controller`
+value MUST conform to the Section [[[#did-syntax]]]. See
 <a data-cite="CID#verification-methods">Section 2.2: Verification Methods</a>
 of the [[[CID]]] specification for a description of [=verification methods=].
       </p>


### PR DESCRIPTION
This PR is an attempt to address issue #880 by clarifying that relative URLs are allowed for verification method identifiers.