### PR TITLE
Clarify that temporary `id` values might be used during operations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1815,8 +1815,8 @@ document=], such as when a [=decentralized identifier=] is being registered in a
 [=verifiable data registry=] or when a [=DID resolver=] is performing [=DID
 resolution=]. These intermediate representations might not contain `id` values,
 or might contain interim values for certain `id` properties. Once the [=DID
-document=]-related operation is complete, the final `id` value will be
-determined and put in place.
+document=] is fully resolved, the final `id` value will be
+determined and put in place of the interim values throughout the [=DID document=].
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1810,11 +1810,13 @@ the [[[CID]]] specification and extended by this specification to include
         </pre>
 
         <p class="note" title="Intermediate representations">
-[=DID method=] specifications can create intermediate representations of a
-[=DID document=] that do not contain the `id` property,
-such as when a [=DID resolver=] is performing [=DID resolution=].
-However, the fully resolved [=DID document=] always contains a valid
-`id` property.
+[=DID method=] specifications can create intermediate representations of a [=DID
+document=], such as when a [=decentralized identifier=] is being registered in a
+[=verifiable data registry=] or when a [=DID resolver=] is performing [=DID
+resolution=]. These intermediate representations might not contain `id` values,
+or might contain interim values for certain `id` properties. Once the [=DID
+document=]-related operation is complete, the final `id` value will be
+determined and put in place.
         </p>
 
       </section>


### PR DESCRIPTION
This PR is an attempt to address issue #866 by clarifying that temporary `id` values might exist during certain DID operations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/894.html" title="Last updated on Jul 10, 2025, 1:39 PM UTC (36d837b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/894/d0be1f3...36d837b.html" title="Last updated on Jul 10, 2025, 1:39 PM UTC (36d837b)">Diff</a>