### PR TITLE
Add warning about comparing DID URLs containing query parameters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1198,11 +1198,12 @@ did:example:123456?versionId=1
 
         <p class="note" title="Avoid comparison of DID URLs containing
           multiple query parameters">
-Implementers are urged to avoid using [=DID URLs=] that contain more than a
-single query parameter when comparing [=DID URLs=] for equivalence. There are
-no normalization rules defined for query parameters in this specification and
-any query parameter normalization rules defined at the DID Method specification
-or application layer are not universally recognized rules.
+Implementers are urged to avoid comparing [=DID URLs=] for equivalence when
+they have more than one query parameter without a specification specifically
+designed for that purpose. This specification defines no normalization rules
+for query parameters, and any query parameter normalization rules defined at
+the DID Method specification or application layer are not universally
+recognized rules.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1195,6 +1195,16 @@ data-cite="RFC3986#section-3.4">RFC&nbsp;3986, section 3.4</a>.
         <pre class="example nohighlight">
 did:example:123456?versionId=1
         </pre>
+
+        <p class="note" title="Avoid comparison of DID URLs containing
+          multiple query parameters">
+Implementers are urged to avoid using [=DID URLs=] that contain more than a
+single query parameter when comparing [=DID URLs=] for equivalence. There are
+no normalization rules defined for query parameters in this specification and
+any query parameter normalization rules defined at the DID Method specification
+or application layer are not universally recognized rules.
+        </p>
+
       </section>
 
       <section class="notoc">


### PR DESCRIPTION
This PR is an attempt to address issue #865 by adding a warning about comparing DID URLs that contain more than a single query parameter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/895.html" title="Last updated on Jul 10, 2025, 1:42 PM UTC (c3a8092)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/895/d0be1f3...c3a8092.html" title="Last updated on Jul 10, 2025, 1:42 PM UTC (c3a8092)">Diff</a>