### PR TITLE
Fix DID fragment examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1225,17 +1225,12 @@ identifiers are shown below.
 
         <pre class="example nohighlight"
              title="A unique verification method in a DID Document">
-did:example:123#public-key-0
+did:example:123#public-key-1
         </pre>
 
         <pre class="example nohighlight"
              title="A unique service in a DID Document">
-did:example:123#agent
-        </pre>
-
-        <pre class="example nohighlight"
-             title="A resource external to a DID Document">
-did:example:123?service=agent&amp;relativeRef=/credentials%23degree
+did:example:123#service-5
         </pre>
 
         <p class="note"


### PR DESCRIPTION
This PR is an attempt to address issue #898 by removing a confusing fragment example from the spec and fixing some of the fragment naming to make it easier to understand what the fragment is pointing to.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/904.html" title="Last updated on Aug 28, 2025, 10:18 PM UTC (4b92154)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/904/3ab8b19...4b92154.html" title="Last updated on Aug 28, 2025, 10:18 PM UTC (4b92154)">Diff</a>